### PR TITLE
(#14) Added support for Facebook federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The following resources are supported:
 * Amazon Cognito federated identities.
   * Amazon Cognito User Pools
   * Google Signin
+  * Facebook Signin
 * Amazon Cognito user pools.
 * S3 buckets for user file storage.
 

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -126,6 +126,7 @@ resources:
         AllowUnauthenticatedIdentities: true
         SupportedLoginProviders:
           accounts.google.com: "abc12345678"
+          graph.facebook.com: "abcdefgh0123456789"
 
     # S3 Bucket for User Files
     UserFiles:

--- a/index.js
+++ b/index.js
@@ -259,6 +259,13 @@ class ServerlessAmplifyPlugin {
                         'ClientId-WebApp': providers['accounts.google.com']
                     };
                 }
+
+                if ('graph.facebook.com' in providers) {
+                    config.FacebookSignin = {
+                        Permisions: "public_profile",
+                        AppId: providers['graph.facebook.com']
+                    };
+                }
             }
         }
 
@@ -338,6 +345,10 @@ class ServerlessAmplifyPlugin {
                 // They are added here in case you need them.
                 if ('accounts.google.com' in providers) {
                     config.google_web_client_id = providers['accounts.google.com'];
+                }
+
+                if ('graph.facebook.com' in providers) {
+                    config.facebook_app_id = providers['graph.facebook.com'];
                 }
             }
         }


### PR DESCRIPTION
*Issue #, if available:*

#14 

*Description of changes:*

* Added support for generating FacebookSignin section in awsconfiguration.json
* Added support for facebook_app_id in the aws-exports.js (not used by Amplify)
* Added test example in the example serverless.yml file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
