### PR TITLE
Let serverless know there's a process running

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ class ServerlessAmplifyPlugin {
             .then(resources => this.describeStackResources(resources))
             .then(resources => this.writeConfigurationFiles(resources))
             .catch(error => this.log('error', `Cannot load resources: ${error.message}`));
+        return resources;
     }
 
     /**


### PR DESCRIPTION
Currently if I run example or my own stack it doesn't generate any files. It looks like serverless is unaware there's process running in the background. If we change process to return the promise, serverless will actually wait for promise to be fulfilled.



*Description of changes:*

- return resources constant from process function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
