### PR TITLE
Recursively list nested stack resources

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,15 @@ class ServerlessAmplifyPlugin {
             request.NextToken = result.NextToken;
             morePages = result.NextToken ? true : false;
         } while (morePages);
+        
+        for (let resource of resources) {
+            if (resource.ResourceType === 'AWS::CloudFormation::Stack') {
+                const nestedStackName = resource.PhysicalResourceId.split('/')[1];
+                resources = resources.concat(
+                    await this.listStackResources(nestedStackName)
+                );
+            }
+        }
 
         return resources;
     }


### PR DESCRIPTION
Update `listStackResources` to recursively list nested stack resources. Creates compatibility with `serverless-plugin-split-stacks`.

*Issue #, if available:*

#44 

*Description of changes:*

Update `listStackResources` to recursively list nested stack resources. Creates compatibility with `serverless-plugin-split-stacks`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
