### PR TITLE
Add non-'.graphql' filetype support for graphql operations codegen

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,15 @@ class ServerlessAmplifyPlugin {
             request.NextToken = result.NextToken;
             morePages = result.NextToken ? true : false;
         } while (morePages);
+        
+        for (let resource of resources) {
+            if (resource.ResourceType === 'AWS::CloudFormation::Stack') {
+                const nestedStackName = resource.PhysicalResourceId.split('/')[1];
+                resources = resources.concat(
+                    await this.listStackResources(nestedStackName)
+                );
+            }
+        }
 
         return resources;
     }

--- a/index.js
+++ b/index.js
@@ -533,7 +533,15 @@ class ServerlessAmplifyPlugin {
         const resource = resources.find(r => r.ResourceType === 'AWS::AppSync::GraphQLApi');
         if (resource) {
             const schemaFile = this.getTemporarySchemaFile(resource);
-            graphqlGenerator(schemaFile, fileDetails.filename, { language: 'graphql' });
+            const fileType = path.extname(fileDetails.filename).substr(1);
+            const language = {
+              ts: 'typescript',
+              js: 'javascript',
+              swift: 'swift',
+              scala: 'scala',
+              graphql: 'graphql',
+            }[fileType];
+            graphqlGenerator(schemaFile, fileDetails.filename, { language });
         } else {
             throw new Error(`No GraphQL API found - cannot write ${fileDetails.filename} file`);
         }


### PR DESCRIPTION
*Issue #, if available:*

#43 

*Description of changes:*

Add non-'.graphql' filetype support for graphql operations codegen. Infer file type by file extension.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
