### PR TITLE
Choose the identity pool that corresponds to the requested app client

### DIFF
--- a/index.js
+++ b/index.js
@@ -265,7 +265,13 @@ class ServerlessAmplifyPlugin {
             }
         }
 
-        const identityPool = resources.find(r => r.ResourceType === 'AWS::Cognito::IdentityPool');
+        const identityPools = resources.filter(r => r.ResourceType === 'AWS::Cognito::IdentityPool');
+        const identityPoolForUserPool = fileDetails.hasOwnProperty('appClient')
+            ? identityPools.find(r => r.metadata.CognitoIdentityProviders &&
+                r.metadata.CognitoIdentityProviders.some(({ClientId}) => ClientId === config.CognitoUserPool.Default.AppClientId)
+            )
+            : undefined;
+        const identityPool = identityPoolForUserPool || identityPools[0];
         if (typeof identityPool !== 'undefined') {
             config.CredentialsProvider = {
                 CognitoIdentity: {
@@ -370,7 +376,13 @@ class ServerlessAmplifyPlugin {
             }
         }
 
-        const identityPool = resources.find(r => r.ResourceType === 'AWS::Cognito::IdentityPool');
+        const identityPools = resources.filter(r => r.ResourceType === 'AWS::Cognito::IdentityPool');
+        const identityPoolForUserPool = fileDetails.hasOwnProperty('appClient')
+            ? identityPools.find(r => r.metadata.CognitoIdentityProviders &&
+                r.metadata.CognitoIdentityProviders.some(({ClientId}) => ClientId === config.aws_user_pools_web_client_id)
+            )
+            : undefined;
+        const identityPool = identityPoolForUserPool || identityPools[0];
         if (typeof identityPool !== 'undefined') {
             if (!config.hasOwnProperty("aws_cognito_region")) {
                 config.aws_cognito_region = identityPool.PhysicalResourceId.split(':')[0];


### PR DESCRIPTION
*Description of changes:* I have multiple identity pools that correspond to each of my user pools. The identity pool that was selected was always the first one, which causes problems with S3 authentication in Amplify. This change selects the identity pool that corresponds to the computed app client ID, and reverts to the old behavior if none is found.

I have verified that it works for me on TS generation, but I don't know how to run local tests (I'll see if CI fails once the PR is submitted).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
