### PR TITLE
Update configuration key to authmode

### DIFF
--- a/index.js
+++ b/index.js
@@ -311,7 +311,7 @@ class ServerlessAmplifyPlugin {
                 Default: {
                     ApiUrl: appSync.metadata.graphqlApi.uris.GRAPHQL,
                     Region: appSync.metadata.graphqlApi.arn.split(':')[3],
-                    AuthType: appSync.metadata.graphqlApi.authenticationType
+                    AuthMode: appSync.metadata.graphqlApi.authenticationType
                 }
             };
         }


### PR DESCRIPTION
*Issue #, if available:*
The iOS App Sync client looks for a key named "AuthMode" which causes a runtime error if the `awsconfiguration.json' file key is named "AuthType."

App Sync client [example](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/blob/94333992713e419af0f78d6d04e627d58e28ec27/AWSAppSyncClient/AWSAppSyncServiceConfig.swift#L73)

*Description of changes:*

Update the App Sync configuration key from `AuthType` to `AuthMode`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.