### PR TITLE
Allow Setting the "maxDepth" Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Each entry in the `amplify` section must consist of two parts, with two optional
     * `appsync` (generated code for AppSync - the format is based on the extension)
 * `appClient` is the name of the Amazon Cognito user pool app client configured within the `resources` section of the `serverless.yml` file.  It is optional.
 * `s3bucket` is the name of the S3 Bucket used for the S3 transfer utility.  It is optional.  If `disabled`, no S3 bucket information is written to the configuration file.  If not included, the first non-deployed S3 bucket will be used.
+* `maxDepth` is the maximum level that an object needs to expand when generating statements. This only applies to `appsync` and `graphql` types.
 
 For the `appsync` type, the extension of the file is checked.  Supported formats include `flow`, `ts` (for TypeScript), `scala`, and `swift`.
 

--- a/index.js
+++ b/index.js
@@ -184,9 +184,9 @@ class ServerlessAmplifyPlugin {
      * @param {Resource} resource the GraphQL API Resource
      * @returns {String} path to the temporary file
      */
-    getTemporaryOperationsFile(resource, schemaFile) {
+    getTemporaryOperationsFile(resource, schemaFile, fileDetails) {
         const operationsFile = path.join('.serverless', 'amplify-operations.graphql');
-        graphqlGenerator(schemaFile, operationsFile, { language: 'graphql' });
+        graphqlGenerator(schemaFile, operationsFile, { language: 'graphql', maxDepth: fileDetails.maxDepth });
         return operationsFile;
     }
 
@@ -542,7 +542,7 @@ class ServerlessAmplifyPlugin {
         const resource = resources.find(r => r.ResourceType === 'AWS::AppSync::GraphQLApi');
         if (resource) {
             const schemaFile = this.getTemporarySchemaFile(resource);
-            graphqlGenerator(schemaFile, fileDetails.filename, { language: 'graphql' });
+            graphqlGenerator(schemaFile, fileDetails.filename, { language: 'graphql', maxDepth: fileDetails.maxDepth });
         } else {
             throw new Error(`No GraphQL API found - cannot write ${fileDetails.filename} file`);
         }
@@ -558,7 +558,7 @@ class ServerlessAmplifyPlugin {
         const resource = resources.find(r => r.ResourceType === 'AWS::AppSync::GraphQLApi');
         if (resource) {
             const schemaFile = path.resolve(this.getTemporarySchemaFile(resource));
-            const graphqlFile = path.resolve(this.getTemporaryOperationsFile(resource, schemaFile));
+            const graphqlFile = path.resolve(this.getTemporaryOperationsFile(resource, schemaFile, fileDetails));
             const fileType = path.extname(fileDetails.filename).substr(1);
             apiGenerator.generate(
                 [ graphqlFile ],        /* List of GraphQL Operations */


### PR DESCRIPTION
*Description of changes:*
I was running into an error when generating documents `appsync` and `graphql` types.

The root of the issue had to do with generating queries when my schema was returning nested types. See [this issue](https://github.com/aws-amplify/amplify-cli/issues/745) for more details.

To address, I added the `maxDepth` option to `fileDetails` when generating `appsync` or `graphql` types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.