### PR TITLE
Write configuration file synchronous

### DIFF
--- a/index.js
+++ b/index.js
@@ -580,11 +580,11 @@ class ServerlessAmplifyPlugin {
      * @param {String} contents the contents of the file
      */
     writeConfigurationFile(filename, contents) {
-        fs.writeFile(filename, contents, 'utf8', (err, data) => {
-            if (err) {
-                this.log('error', `Writing to ${filename}: ${err}`);
-            }
-        });
+        try {
+            fs.writeFileSync(filename, contents, 'utf8')
+        } catch (err) {
+            this.log('error', `Writing to ${filename}: ${err}`);
+        }
     }
 }
 


### PR DESCRIPTION
Issue #54 

*Description of changes:*
When the stack has no changes on serverless, the deploy is skipped and as  the configuration file is written in an asynchronous method, this can cause an abruptly exit on the process before the writing is done, this results on a empty configuration file. Now the configuration file is written on a synchronous method, even if the deploy is skipped, the application waits the writing process to be done.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
