### PR TITLE
Add ability to reference UserPool and IdentityPool resources from another stack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Each entry in the `amplify` section must consist of two parts, with two optional
 
 For the `appsync` type, the extension of the file is checked.  Supported formats include `flow`, `ts` (for TypeScript), `scala`, and `swift`.
 
+Cross stack `appClient` / `identityPool` configuration only supports `Amazon Cognito User Pools`. Other providers like Google are not tested or implemented yet.
+
 See the `example` directory for a complete sample of an AWS AppSync client deployment with Amazon Cognito user pools.
 
 ### Another Example

--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ Each entry in the `amplify` section must consist of two parts, with two optional
     * `schema.json` (the AWS AppSync schema in JSON format),
     * `graphql` (a sample GraphQL operations file for codegen),
     * `appsync` (generated code for AppSync - the format is based on the extension)
-* `appClient` is the name of the Amazon Cognito user pool app client configured within the `resources` section of the `serverless.yml` file.  It is optional.
+* `appClient` is the name of the Amazon Cognito user pool app client configured within the `resources` section of the `serverless.yml` file. Define the individual properties for resources on a different stack. It is optional.
+  * `UserPoolId` (reference to a UserPool in another stack)
+  * `ClientId` (the ClientId of a UserPoolClient in another stack)
+  * `ClientSecret` (optional ClientSecret. **Must be entered manually.** CF doesn't support the export of this value.)
+* `identityPool` (optional reference to an IdentityPool in another stack)
 * `s3bucket` is the name of the S3 Bucket used for the S3 transfer utility.  It is optional.  If `disabled`, no S3 bucket information is written to the configuration file.  If not included, the first non-deployed S3 bucket will be used.
 
 For the `appsync` type, the extension of the file is checked.  Supported formats include `flow`, `ts` (for TypeScript), `scala`, and `swift`.

--- a/index.js
+++ b/index.js
@@ -618,7 +618,14 @@ class ServerlessAmplifyPlugin {
                 fileDetails.appClient.UserPoolId 
                 && fileDetails.appClient.ClientId
             ) {
-                appClient = fileDetails.appClient;
+                appClient = {
+                    metadata: {
+                        UserPoolClient: {
+                            UserPoolId: fileDetails.appClient.UserPoolId,
+                            ClientId: fileDetails.appClient.ClientId
+                        }
+                    }
+                };
             }
         } catch (e) {
             console.log('No manual appClient configuration available.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-serverless-plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A plugin for the Serverless Framework that outputs AWS Amplify artifacts based on the deployed resources.",
   "keywords": [
     "serverless",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-serverless-plugin",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A plugin for the Serverless Framework that outputs AWS Amplify artifacts based on the deployed resources.",
   "keywords": [
     "serverless",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently there's no way to define an `appClient` manually by passing the `UserPool(Client)` and `IdentityPool` in using values from a CF stack variable reference.

This enhances the configuration options to do just that. 

For configuration see the updated README.md

There was a previous pull request to do this, but as far as I was able to tell it wasn't implemented for both native and Javascript configurations. It was never merged also.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
